### PR TITLE
add card reader driver package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN \
 	libcrypto1.0 \
 	libssl1.0 \
 	libusb \
+	ccid \
 	pcsc-lite \
 	pcsc-lite-libs && \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,10 @@ RUN \
 
 # install runtime packages
  apk add --no-cache \
+	ccid \
 	libcrypto1.0 \
 	libssl1.0 \
 	libusb \
-	ccid \
 	pcsc-lite \
 	pcsc-lite-libs && \
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The web interface is at port 8888.
 
 ## Versions
 
++ **19.10.2017:** Add ccid package for usb card readers.
 + **17.10.2017:** Switch to using bzr for source code, streamboard awol.
 + **28.05.2017:** Rebase to alpine 3.6.
 + **09.02.2017:** Rebase to alpine 3.5.


### PR DESCRIPTION
My card reader "ID 08e6:3437 Gemalto (was Gemplus) GemPC Twin SmartCard Reader" was not working due to missing driver, adding package ccid solves this. It also includes drivers for many other readers.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

