### PR TITLE
httpallowed bugfix - 172.16.*/12 added

### DIFF
--- a/root/defaults/oscam.conf
+++ b/root/defaults/oscam.conf
@@ -10,4 +10,3 @@ logfile                       = stdout
 [webif]
 httpport                      = 8888
 httpallowed                   = 127.0.0.1,192.168.0.0-192.168.255.255,10.0.0.0-10.255.255.255,172.16.0.0-172.31.255.255,255.255.255.255
-https://github.com/linuxserver/docker-oscam/blob/master/root/defaults/oscam.conf

--- a/root/defaults/oscam.conf
+++ b/root/defaults/oscam.conf
@@ -9,4 +9,5 @@ logfile                       = stdout
 
 [webif]
 httpport                      = 8888
-httpallowed                   = 127.0.0.1,192.168.0.0-192.168.255.255,10.0.0.0-10.255.255.255,255.255.255.255
+httpallowed                   = 127.0.0.1,192.168.0.0-192.168.255.255,10.0.0.0-10.255.255.255,172.16.0.0-172.31.255.255,255.255.255.255
+https://github.com/linuxserver/docker-oscam/blob/master/root/defaults/oscam.conf


### PR DESCRIPTION
 httpallowed->added private 172.16.* class B subnet

Ubuntu 18.08 with latest "apt" docker-version (fresh install) defaulted to 172.16.0.1 and .2 addresses, resulting in a "403 access denied" error (webif inaccessible).

Enviroment:
```
folfy@folfnuc:/mnt/vm/data$ lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 18.04.1 LTS
Release:	18.04
Codename:	bionic
folfy@folfnuc:/mnt/vm/data$ docker --version
Docker version 17.12.1-ce, build 7390fc6
```

Resulted in:
```
folfy@folfnuc:~$ ip route show 
default via 192.168.1.1 dev eno1 proto dhcp metric 100 
169.254.0.0/16 dev eno1 scope link metric 1000 
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 
192.168.1.0/24 dev eno1 proto kernel scope link src 192.168.1.10 metric 100 
```
